### PR TITLE
Adding the newly created API endpoint: return-period

### DIFF
--- a/api-gateway/access_points_config.yaml
+++ b/api-gateway/access_points_config.yaml
@@ -7,6 +7,53 @@ schemes:
   - https
 produces:
   - application/json
+x-google-management:
+  metrics:
+    # Define a metric for forecast requests.
+    - name: "forecast-requests"
+      displayName: "Forecast requests"
+      valueType: INT64
+      metricKind: DELTA
+    # Define a metric for analysis-assim requests.
+    - name: "assim-requests"
+      displayName: "Analysis-assim requests"
+      valueType: INT64
+      metricKind: DELTA
+    # Define a metric for geometry requests.
+    - name: "geometry-requests"
+      displayName: "Geometry requests"
+      valueType: INT64
+      metricKind: DELTA
+    - name: "return-period-requests"
+      displayName: "Return-period requests"
+      valueType: INT64
+      metricKind: DELTA
+  quota:
+    limits:
+      # Rate limit for forecast requests.
+      - name: "forecast-request-limit"
+        metric: "forecast-requests"
+        unit: "1/min/{project}"
+        values:
+          STANDARD: 1000
+      # Rate limit for analysis-assim requests.
+      - name: "assim-request-limit"
+        metric: "assim-requests"
+        unit: "1/min/{project}"
+        values:
+          STANDARD: 1000
+      # Rate limit for geometry requests.
+      - name: "geometry-request-limit"
+        metric: "geometry-requests"
+        unit: "1/min/{project}"
+        values:
+          STANDARD: 1000
+      # Rate limit for return-period requests.
+      - name: "return-period-request-limit"
+        metric: "return-period-requests"
+        unit: "1/min/{project}"
+        values:
+          STANDARD: 1000
 paths:
   /:
     get:
@@ -83,6 +130,9 @@ paths:
           description: "Output format. Options are csv and json"
           required: true
           type: "string"
+      x-google-quota:
+        metricCosts:
+          forecast-requests: 1
       security:
         - api_key: []
       responses:
@@ -140,6 +190,9 @@ paths:
           description: "Output format. Options are csv and json"
           required: true
           type: "string"
+      x-google-quota:
+        metricCosts:
+          assim-requests: 1
       security:
         - api_key: []
       responses:
@@ -192,6 +245,9 @@ paths:
           description: "Output format. Options are csv and json"
           required: true
           type: "string"
+      x-google-quota:
+        metricCosts:
+          geometry-requests: 1
       security:
         - api_key: []
       responses:
@@ -245,6 +301,9 @@ paths:
           description: "Ordering the records in the resulting data table" 
           required: false
           type: "boolean"
+      x-google-quota:
+        metricCosts:
+          return-period-requests: 1
       security:
         - api_key: []
       responses:

--- a/api-gateway/access_points_config.yaml
+++ b/api-gateway/access_points_config.yaml
@@ -1,8 +1,8 @@
 swagger: '2.0'
 info:
-  title: NWM Streams API 1.1
+  title: NWM Streams API
   description: Retrieves data from NWM Dataset based on given parameters
-  version: 0.1.1
+  version: 1.1.0
 schemes:
   - https
 produces:

--- a/api-gateway/access_points_config.yaml
+++ b/api-gateway/access_points_config.yaml
@@ -1,16 +1,28 @@
 swagger: '2.0'
 info:
-  title: NWM Streams API
+  title: NWM Streams API 1.1
   description: Retrieves data from NWM Dataset based on given parameters
-  version: 1.0.0
+  version: 0.1.1
 schemes:
   - https
 produces:
   - application/json
 paths:
+  /:
+    get:
+      summary: Home for NWM API
+      operationId: home
+      x-google-backend:
+        address: <APP_URL>
+        path_translation: APPEND_PATH_TO_ADDRESS
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string
   /docs:
     get:
-      summary: Documentation for NWM Streams API
+      summary: Documentation for NWM API
       operationId: docs
       x-google-backend:
         address: <APP_URL>
@@ -20,9 +32,10 @@ paths:
           description: A successful response
           schema:
             type: string
+
   /openapi.json:
     get:
-      summary: openapi.json for NWM Streams API
+      summary: openapi.json for NWM API
       operationId: openapi-json
       x-google-backend:
         address: <APP_URL>
@@ -198,6 +211,60 @@ paths:
           description: "Internal Server Error"
           schema:
             type: string
+
+  /return-period:
+    get:
+      summary: Get flood return-period contents
+      operationId: return_periods
+      x-google-backend:
+        address: <APP_URL>
+        path_translation: APPEND_PATH_TO_ADDRESS
+      parameters:
+        - name: "comids"
+          in: "query"
+          description: "Unique identification for stream segment"
+          required: true
+          type: "number"
+        - name: "hydoshare_id"
+          in: "query"
+          description: "Unique identification for HydroShare resource (with list of comids)"
+          required: true
+          type: "number"
+        - name: "return_periods"
+          in: "query"
+          description: "Extraction of a subset of available return periods" 
+          required: false
+          type: "string"
+        - name: "output_format"
+          in: "query"
+          description: "Output format. Options are csv and json"
+          required: true
+          type: "string"
+        - name: "order_by_comid"
+          in: "query"
+          description: "Ordering the records in the resulting data table" 
+          required: false
+          type: "boolean"
+      security:
+        - api_key: []
+      responses:
+        "200":
+          description: "Successful retrieval of data"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Response"
+        "400":
+          description: "Invalid parameters provided"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "500":
+          description: "Internal Server Error"
+          schema:
+            type: string
+
 securityDefinitions:
   api_key:
     type: "apiKey"

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -28,7 +28,7 @@ def custom_openapi():
         return app.openapi_schema
     openapi_schema = get_openapi(
         title="National Water Model API Documentation",
-        version="0.1.1",
+        version="1.1.0",
         summary="This is the OpenAPI schema for the National Water Model API.",
         description = (
             "This API provides access to data produced by the National Water Model.\n"

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,32 +1,34 @@
+# Import libraries required for data processing
 import csv
 from datetime import datetime
 from dateutil import parser
 from io import StringIO
 import requests
 
+# Import libraries associated with FastAPI and BIGQUERY
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.openapi.utils import get_openapi
 from google.cloud import bigquery
 from typing import Union
 
-
-# constants
+# Strings corresponding to BIGQUERY table names for different forecast options
 FORECAST_OPTS = dict(
     long_range = 'bigquery-public-data.national_water_model.long_range_channel_rt',
     medium_range = 'bigquery-public-data.national_water_model.medium_range_channel_rt',
     short_range = 'bigquery-public-data.national_water_model.short_range_channel_rt',
 )
 
+# Create an app instance of the class FastAPI
 app = FastAPI()
 
-
+# Customize the documentation page as per the OpenAPI framework
 def custom_openapi():
     if app.openapi_schema:
         return app.openapi_schema
     openapi_schema = get_openapi(
         title="National Water Model API Documentation",
-        version="0.1.0",
+        version="0.1.1",
         summary="This is the OpenAPI schema for the National Water Model API.",
         description = (
             "This API provides access to data produced by the National Water Model.\n"
@@ -37,20 +39,26 @@ def custom_openapi():
         routes=app.routes,
     )
     openapi_schema["info"]["x-logo"] = {
-        "url": "https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png"
+        "url": "https://ciroh.ua.edu/wp-content/uploads/2022/08/CIROHLogo_200x200.png"
     }
     app.openapi_schema = openapi_schema
     return app.openapi_schema
 
-
+# Add the custom documentation in the generated API application
 app.openapi = custom_openapi
 
+
+# Create path operation decorator for the DOCUMENTATION API
 @app.get("/")
-def home():
+
+# Define the ROOT function
+def root():
     return RedirectResponse("/docs")
 
-
+# Create path operation decorator for the FORECAST API
 @app.get("/forecast")
+
+# Define the FORECAST function
 def forecast(
     forecast_type: str,
     reference_time: str | None = None,
@@ -59,22 +67,34 @@ def forecast(
     ensemble: str | None = None,
     output_format: str = 'json',
 ):
-    """Retrieve analysis assimilation data from the National Water Model based on the provided parameters.
+    """Retrieve forecast data from the National Water Model based on the provided parameters.
 
     Args:
 
         forecast_type (str): The forecast run to extract data from.
+            Supported values are 'long_range', 'medium_range', and 'short_range'.
         reference_time (str, optional): The reference time for the forecast.
-            If None then defaults to the latest available forecast reference time 
-            in specified table. Defaults to None.
-        comids (str, optional): A comma-separated list of comids for the forecast. 
+            If None then defaults to the latest available forecast reference time
+            in specified table.
             Defaults to None.
+            Example: "2023-11-25 06:00:00 UTC"
+        comids (str, optional): A comma-separated list of reach IDs for the forecast.
+            Defaults to None.
+            Example: "15039097,1239657"
         hydroshare_id (str, optional): The hydroshare id with specified comids to
-            extractt the forecast. If comids is not provided, this will be used 
-            to extract comids. Defaults to None.
-        ensemble (str, optional): A comma-separated list of ensembles for the forecast. 
-            If None then the average of all available ensembles will be taken. Defaults to None.
-        output_format (str, optional): The output format for the forecast. Defaults to 'json'.
+            extract the forecast. If comids is not provided, this will be used
+            to extract comids.
+            Defaults to None.
+            Example: "643dc03878704a30849536e302bdb2c0"
+        ensemble (str, optional): A comma-separated list of ensembles for the forecast.
+            If None then the average of all available ensembles will be taken.
+            Defaults to None.
+            Supported values are 0 for short_range, 0 to 5 for medium_range, and
+            0 to 3 for long_range
+        output_format (str, optional): The output format for the forecast dataset.
+            Defaults to 'json'.
+            Supported values are 'json' and 'csv'.
+
 
     Returns:
 
@@ -91,11 +111,11 @@ def forecast(
     if reference_time is None:
         # Query to get the latest reference_time
         latest_reference_time_query = f"""
-            SELECT 
+            SELECT
                 MAX(reference_time) AS latest_reference_time
-            FROM 
+            FROM
                 `{table_name}`
-            WHERE 
+            WHERE
                 DATETIME(reference_time) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
                 AND feature_id = 101
                 AND ensemble = 0
@@ -116,7 +136,7 @@ def forecast(
 
     # Extract comids from either the comid or hydroshare_id input
     comids = extract_comid_input(comids, hydroshare_id)
-    
+
     # If ensemble is provided, split by comma
     ensembles = list(map(int, ensemble.split(','))) if ensemble else None
 
@@ -133,9 +153,9 @@ def forecast(
                     'average' AS ensemble,
                     AVG(streamflow) AS streamflow,
                     AVG(velocity) AS velocity
-                FROM 
+                FROM
                     `{table_name}`
-                WHERE 
+                WHERE
                     feature_id IN ({", ".join(map(str, comids))})
                     AND reference_time = '{reference_time}'
                 GROUP BY
@@ -148,20 +168,20 @@ def forecast(
     else:
         # If ensemble(s) is specified, use them in the query
         query = f"""
-            SELECT 
+            SELECT
                 feature_id,
                 reference_time,
                 time,
                 ensemble,
                 streamflow,
                 velocity
-            FROM 
+            FROM
                 `{table_name}`
-            WHERE 
+            WHERE
                 feature_id IN ({", ".join(map(str, comids))})
                 AND reference_time = '{reference_time}'
                 AND ensemble IN ({", ".join(map(str, ensembles))})
-            ORDER BY 
+            ORDER BY
                 time
         """
 
@@ -182,11 +202,13 @@ def forecast(
         response_data.append(json_obj)
 
     response = format_response(response_data, output_format)
-    
+
     return response
 
-
+# Create path operation decorator for the Analysis-Assimilation API
 @app.get("/analysis-assim")
+
+# Define the Analysis-Assimilation app function
 def analysis_assim(
     start_time: str | None = None,
     end_time: str | None = None,
@@ -198,20 +220,26 @@ def analysis_assim(
     """
     Retrieve the analysis assimilation data from the National Water Model for the specified parameters.
 
-    
     Args:
 
-        start_time (str | None): The start time of the data range. If None, defaults to "2018-09-17T00:00:00".
+        start_time (str | None): The start time of the data range.
+            Defaults to None. If None, defaults to "2018-09-17T00:00:00".
+        end_time (str | None): The end time of the data range.
+            Defaults to None. If None, defaults to the current time.
+        comids (str, optional): A comma-separated list of reach IDs for the forecast.
             Defaults to None.
-        end_time (str | None): The end time of the data range. If None, defaults to the current time.
-            Defaults to None.
-        comids (str, optional): A comma-separated list of comids for the forecast. 
-            Defaults to None.
+            Example: "15039097,1239657"
         hydroshare_id (str, optional): The hydroshare id with specified comids to
-            extract the forecast. If comids is not provided, this will be used 
-            to extract comids. Defaults to None.
-        output_format (str): The format of the response data. Defaults to 'json'.
-        run_offset (int): The analysis_assim result time offset. Supported values are 1, 2, and 3. Defaults to 1.
+            extract the forecast. If comids is not provided, this will be used
+            to extract comids.
+            Defaults to None.
+            Example: "643dc03878704a30849536e302bdb2c0"
+        output_format (str): The format of the analysis-assimilation response data.
+            Defaults to 'json'.
+            Supported values are 'json' and 'csv'.
+        run_offset (int): The analysis_assim result time offset.
+            Defaults to 1.
+            Supported values are 1, 2, and 3.
 
     Returns:
 
@@ -223,8 +251,8 @@ def analysis_assim(
     comids = extract_comid_input(comids, hydroshare_id)
 
     if run_offset not in range(1,4):
-        raise HTTPException(status_code=400, detail=f"Invalid run_offset. Supported values are 1, 2, and 3.")
-    
+        raise HTTPException(status_code=400, detail="Invalid run_offset. Supported values are 1, 2, and 3.")
+
     if start_time is None:
         start_time = "2018-09-17T00:00:00"
 
@@ -239,12 +267,12 @@ def analysis_assim(
             velocity
         FROM
             `bigquery-public-data.national_water_model.analysis_assim_channel_rt`
-        WHERE 
+        WHERE
             feature_id IN ({", ".join(map(str, comids))})
             AND forecast_offset = {run_offset}
             AND time >= '{start_time}'
             AND time <= '{end_time}'
-        ORDER BY 
+        ORDER BY
             time
     """
 
@@ -268,7 +296,11 @@ def analysis_assim(
 
     return response
 
+
+# Create path operation decorator for the Geometry API
 @app.get("/geometry")
+
+# Define the GEOMETRY app function
 def geometry(
     comids: str | None = None,
     hydroshare_id: str | None = None,
@@ -281,19 +313,27 @@ def geometry(
 
     Args:
 
-        comids (str, optional): A comma-separated list of comids for the forecast. 
+        comids (str, optional): A comma-separated list of comids for the forecast.
             Defaults to None.
+            Example: "15039097,1239657"
         hydroshare_id (str, optional): The hydroshare id with specified comids to
-            extractt the forecast. If comids is not provided, this will be used 
-            to extract comids. Defaults to None.
-        lat (float, optional): A latitude value to query using a geomtry point. 
-            Must provide lon as well if provided. Defaults to None.
-        lon (float, optional): A longitude value to query using a geomtry point. 
-            Must provide lat as well if provided. Defaults to None.
-        output_format (str, optional): The output format for the forecast. Defaults to 'json'.
-
+            extractt the forecast. If comids is not provided, this will be used
+            to extract comids.
+            Defaults to None.
+            Example: "643dc03878704a30849536e302bdb2c0"
+        lat (float, optional): A latitude value to query using a geometry point.
+            Must provide lon as well if provided.
+            Defaults to None.
+            Example: 40.0
+        lon (float, optional): A longitude value to query using a geometry point.
+            Must provide lat as well if provided.
+            Defaults to None.
+            Example: -111.0
+        output_format (str, optional): The output format of the geometry data.
+            Defaults to 'json'.
+            Supported values are 'json' and 'csv'.
     Returns:
-    
+
         The geometry data in the specified output format.
     """
     # Validate input combinations
@@ -306,13 +346,13 @@ def geometry(
 
         # Construct the BigQuery query to select specific columns with a JOIN statement
         query = f"""
-            SELECT 
+            SELECT
                 *
-            FROM 
+            FROM
                 `bigquery-public-data.national_water_model.stream_network`
-            WHERE 
+            WHERE
                 station_id IN ({", ".join(map(str, station_ids))})
-            ORDER BY 
+            ORDER BY
                 station_id
         """
 
@@ -332,21 +372,21 @@ def geometry(
 
         # Construct the BigQuery query to select specific columns with a JOIN statement
         query = f"""
-            SELECT 
+            SELECT
                 *
-            FROM 
+            FROM
                 `bigquery-public-data.national_water_model.stream_network`
-            WHERE 
+            WHERE
                 station_id IN ({", ".join(map(str, station_ids))})
-            ORDER BY 
+            ORDER BY
                 station_id
         """
-    
+
     elif lat and lon:
         # If lat and lon are provided, find the closest 'to' using Haversine formula
         query = f"""
             SELECT
-                streams.*,    
+                streams.*,
                 ST_DISTANCE(streams.geometry, ST_GEOGPOINT({lon}, {lat})) AS distance
             FROM
                 `bigquery-public-data.national_water_model.stream_network` AS streams
@@ -373,6 +413,97 @@ def geometry(
     return response
 
 
+# Create path operation decorator for the Flood Return-Periods API
+@app.get("/return-period")
+
+# Define the Flood Return-Periods app function
+def flood_return_periods(
+    comids: str | None = None,
+    hydroshare_id: str | None = None,
+    return_periods: str | None = None,
+    output_format: str = 'json',
+    order_by_comid: bool = False,
+):
+    """
+    Retrieve the flood return-periods data for specified reach IDs in desired output format.
+
+
+    Args:
+
+        comids (str, optional): A comma-separated list of comids for the return-
+            periods data.
+            Defaults to None.
+            Example: "15039097,1239657"
+        hydroshare_id (str, optional): The hydroshare id with specified comids to
+            extract the forecast. If comids is not provided, this will be used
+            to extract comids.
+            Defaults to None.
+            Example: "643dc03878704a30849536e302bdb2c0"
+        return_periods (str, optional): A comma-separated list of return-period
+            fields to be included in the response.
+            Defaults to None. None will extract all six return-periods namely
+            2, 5, 10, 25, 50, and 100.
+            Example: "10,50,100"
+        output_format (str): The format of the return-period response data.
+            Defaults to 'json'.
+            Supported values are 'json' and 'csv'.
+        order_by_comid (bool, optional): Whether to order the results by comids.
+            Defaults to False. The records will be in the order of input comids
+            If True, the results will be ordered by comids in ascending order.
+
+    Returns:
+
+        The flood return periods data in the specified output format.
+
+    """
+
+    # Extract comids from either the comid or hydroshare_id input
+    comids = extract_comid_input(comids, hydroshare_id)
+
+    # Customize extracted fields based on return_periods chosen
+    selected_fields = "feature_id"
+    tabs = "\t    "
+    if return_periods == None:
+      # Extract all six return periods data by default
+      selected_fields = (selected_fields +
+                        (f",\n{tabs}return_period_2,\n{tabs}return_period_5," +
+                        f"\n{tabs}return_period_10,\n{tabs}return_period_25," +
+                        f"\n{tabs}return_period_50, \n{tabs}return_period_100"))
+    else:
+      # Extract only the listed return periods data
+      requested_return_periods = return_periods.split(",")
+      for return_period in requested_return_periods:
+          selected_fields = selected_fields + f",\n{tabs}return_period_{return_period}"
+
+    # Assemble the main body of the flood return-period data query
+    query = f"""
+            SELECT
+                {selected_fields}
+            FROM
+                `bigquery-public-data.national_water_model.flood_return_periods`
+            WHERE
+                feature_id IN ({", ".join(map(str, comids))})
+        """
+
+    if order_by_comid:
+      #  Add the sorting statement if order_by_comid is True
+      query += "    ORDER BY feature_id"
+
+
+    # Make API request to BigQuery and retrieve data
+    results = run_query(query)
+
+     # Create a list of JSON objects with the selected columns
+    response_data = []
+    for row in results:
+        # Convert the BigQuery Row object to a dictionary
+        json_obj = dict(row.items())
+        response_data.append(json_obj)
+
+    response = format_response(response_data, output_format)
+
+    return response
+
 def run_query(query):
     # Set up BigQuery client
     client = bigquery.Client()
@@ -395,17 +526,17 @@ def extract_comid_input(comids: str | None, hydroshare_id: str | None):
             hydroshare_data = hydroshare_response.json()
             # Extract comids from the HydroShare data
             comids = [item.get('comid') for item in hydroshare_data]
-            
+
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error retrieving HydroShare data: {str(e)}")
-        
+
     elif comids:
         # If comids is provided, split by comma
         comids = list(map(int, comids.split(','))) if comids else None
 
     else:
         raise HTTPException(status_code=400, detail="No valid comids found. Please provide valid comids or a valid HydroShare resource ID.")
-    
+
     return comids
 
 def format_response(response_data, output_format):
@@ -413,7 +544,7 @@ def format_response(response_data, output_format):
     if output_format.lower() == 'json':
         # Return results as a JSON response
         response = JSONResponse(content=response_data)
-    
+
     elif output_format.lower() == 'csv':
         # Return results as a CSV response
         csv_output = StringIO()
@@ -433,5 +564,5 @@ def format_response(response_data, output_format):
         csv_output.close()
     else:
         raise HTTPException(status_code=400, detail='Unsupported output format. Supported formats are JSON and CSV.')
-    
+
     return response

--- a/src/cloudbuild.yaml
+++ b/src/cloudbuild.yaml
@@ -4,13 +4,13 @@ steps:
   args: 
   - 'build'
   - '-t'
-  - 'us-central1-docker.pkg.dev/kmarkert-personal/nwm-api-repo/nwm-api-image'
+  - 'us-central1-docker.pkg.dev/bigqueryapi-430214/nwm-api-repo/nwm-api-image'
   - '.'
 # Push the container image to Container Registry
 - name: 'gcr.io/cloud-builders/docker'
   args: 
   - 'push'
-  - 'us-central1-docker.pkg.dev/kmarkert-personal/nwm-api-repo/nwm-api-image'
+  - 'us-central1-docker.pkg.dev/bigqueryapi-430214/nwm-api-repo/nwm-api-image'
 # Deploy container image to Cloud Run
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   entrypoint: gcloud
@@ -19,7 +19,7 @@ steps:
   - 'deploy'
   - 'nwm-api-service'
   - '--image'
-  - 'us-central1-docker.pkg.dev/kmarkert-personal/nwm-api-repo/nwm-api-image'
+  - 'us-central1-docker.pkg.dev/bigqueryapi-430214/nwm-api-repo/nwm-api-image'
   - '--region'
   - 'us-central1'
   - '--memory'
@@ -33,6 +33,6 @@ steps:
   - '--timeout'
   - '30s'
   - '--service-account'
-  - 'nwm-api-controller@kmarkert-personal.iam.gserviceaccount.com'
+  - 'nwm-api-controller@bigqueryapi-430214.iam.gserviceaccount.com'
 images:
-- 'us-central1-docker.pkg.dev/kmarkert-personal/nwm-api-repo/nwm-api-image'
+- 'us-central1-docker.pkg.dev/bigqueryapi-430214/nwm-api-repo/nwm-api-image'


### PR DESCRIPTION
A new endpoint has been created for the existing NWM API for accessing the NWM Return Period dataset. This endpoint has a structure consistent with the other existing endpoints and is able to extract desired data portion using a combination of parameters such as comids (reach IDs), hydroshare_id, return_periods, output_format, and order_by_comid.